### PR TITLE
Add installation options to the README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+xcuserdata/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 A network mocking layer for iOS and macOS
 
-More to come!
+## Installation
 
-Created by sebastian.celis@buzzfeed.com
+### CocoaPods
+
+[CocoaPods](https://cocoapods.org/) is a dependency manager for Swift and Objective-C Cocoa projects. To integrate MockDuck into your project, specify it in your `Podfile`:
+
+```ruby
+pod 'MockDuck'
+```
+
+### Carthage
+
+[Carthage](https://github.com/Carthage/Carthage) is a simple, decentralized dependency manager for Cocoa. To integrate MockDuck into your project, add the following to your `Cartfile`:
+
+```ruby
+github "BuzzFeed/MockDuck" "master"
+```
+
+### Manually
+
+MockDuck can also be integrated into your project manually by using git submodules. Once you have added your submodule, simply drag `MockDuck.xcodeproj` into your Xcode project or workspace and then have your target link against `MockDuck.framework`.


### PR DESCRIPTION
No swift package manager support until we can remove the objective-c code.