### PR TITLE
Remove shared instantiation of MockDuck

### DIFF
--- a/MockDuck/Sources/MockBundle.swift
+++ b/MockDuck/Sources/MockBundle.swift
@@ -141,7 +141,7 @@ public class MockBundle {
                     try sequence.responseData?.write(to: dataOutputPath, options: [.atomic])
                 }
 
-                if MockDuck.shared.isVerbose {
+                if MockDuck.isVerbose {
                     print("[MockDuck] Persisted request at \(outputPath).")
                 }
             } else {

--- a/MockDuck/Sources/MockDataTask.swift
+++ b/MockDuck/Sources/MockDataTask.swift
@@ -36,7 +36,7 @@ class MockDataTask: URLSessionDataTask {
             // The request is found. Load the MockSequence and call the completion/finish with the
             // stored data.
             completion?(sequence, true, nil)
-        } else if MockDuck.shared.shouldFallbackToNetwork {
+        } else if MockDuck.shouldFallbackToNetwork {
             // The request isn't found but we should fallback to the network. Kick off a task with
             // the internal URLSession.
             let dataTask = session.internalSession.dataTask(with: request, completionHandler: { [weak self] (data, response, error) in

--- a/MockDuck/Sources/MockDuck.swift
+++ b/MockDuck/Sources/MockDuck.swift
@@ -21,35 +21,44 @@ public protocol MockDuckDelegate: class {
     func useBodyInRequestHash(url: URL) -> Bool
 }
 
-/// MockDuck top level class for starting, stopping, and configuring the framework.
-/// This class is responsible for registering MockDuck as a URLProtocol that allows
-/// it to intercept all (well, most of) the network traffic.
+// MARK: -
+
+/// MockDuck top level class for configuring the framework. This class is responsible for
+/// registering MockDuck as a URLProtocol that allows it to intercept network traffic.
 public class MockDuck {
     static let requestQueue = DispatchQueue(label: "com.buzzfeed.MockDuck.sessionQueue", attributes: [])
 
-    public static let shared = MockDuck()
-    public weak var delegate: MockDuckDelegate?
-    public var isVerbose = false
+    public static weak var delegate: MockDuckDelegate?
+    public static var isVerbose = false
 
-    private let registeredMocks = [MockSequence]()
+    private static let registeredMocks = [MockSequence]()
 
-    private var requestBundle: MockBundle {
+    private static var requestBundle: MockBundle {
         return session.bundle
     }
     
-    var session = MockSession(
+    static var session = MockSession(
         requestBundle: MockBundle(),
         requestQueue: MockDuck.requestQueue
     )
 
-    public var enabled = true
-    public var shouldFallbackToNetwork = true
+    /// By default, MockDuck is enabled, even though it does nothing until configured by setting
+    /// `baseURL`, `recordURL`, or by registering a request mock. This is here, however, to allow
+    /// developers to quickly disable MockDuck by setting this to `false`.
+    public static var enabled = true
 
-    private init() {
-        URLProtocol.registerClass(MockURLProtocol.self)
-    }
+    /// By default, MockDuck will fallback to making a network request if the request can not be
+    /// loaded from `baseURL` or if the request can not be handled by a registered request mock.
+    /// Set this to `false` to force an error that resembles what `URLSession` provides when the
+    /// network is unreachable.
+    public static var shouldFallbackToNetwork = true
 
-    public var baseURL: URL? {
+    /// The location where MockDuck will attempt to look for network requests that have been saved
+    /// to disk.
+    public static var baseURL: URL? {
+        willSet {
+            checkConfigureMockDuck()
+        }
         didSet {
             requestBundle.baseURL = baseURL
             if let baseURL = baseURL {
@@ -58,7 +67,13 @@ public class MockDuck {
         }
     }
 
-    public var recordURL: URL? {
+    /// The location where MockDuck should attempt to save network requests that occur. This is a
+    /// useful way to record a session of network activity to disk which is then used in the future
+    /// by pointing to this same data using `baseURL`.
+    public static var recordURL: URL? {
+        willSet {
+            checkConfigureMockDuck()
+        }
         didSet {
             requestBundle.recordURL = recordURL
             if let recordURL = recordURL {
@@ -67,15 +82,35 @@ public class MockDuck {
         }
     }
 
-    public func hasRegisteredRequestMocks() -> Bool {
-        return requestBundle.hasRegisteredRequestMocks()
-    }
-
-    public func registerRequestMock(with block: @escaping MockBundle.RequestMock) {
+    /// This function allows one to hook into MockDuck by allowing the caller to override any
+    /// request with a specified response. This is most often used in unit tests to mock out
+    /// expected requests so that the network isn't actually hit, introducing instability to the
+    /// test.
+    ///
+    /// - Parameter block: The block to register. It receives a single parameter being the
+    /// URLRequest that is about to be made. This block should return `nil` to do nothing with that
+    /// request. Otherwise, it should return a `MockResponse` object that describes the full
+    /// response that should be used for that request. You can use the extensions provided to
+    /// `URLRequest.` to easily create a `MockResponse` for any request. See the various
+    /// `mockResponse` functions in `URLRequest+Extensions.swift`.
+    public static func registerRequestMock(with block: @escaping MockBundle.RequestMock) {
+        checkConfigureMockDuck()
         requestBundle.registerRequestMock(with: block)
     }
 
-    public func unregisterAllRequestMocks() {
+    /// Quickly unregister all mocks that were registered by calling `registerRequestMock`. You
+    /// generally want to call this in the `tearDown` method of your unit tests.
+    public static func unregisterAllRequestMocks() {
         requestBundle.unregisterAllRequestMocks()    
+    }
+
+    // MARK: - Private Configuration
+
+    private static var isConfigured = false
+
+    private static func checkConfigureMockDuck() {
+        guard !isConfigured else { return }
+        URLProtocol.registerClass(MockURLProtocol.self)
+        isConfigured = true
     }
 }

--- a/MockDuck/Sources/MockSerializable.swift
+++ b/MockDuck/Sources/MockSerializable.swift
@@ -77,7 +77,7 @@ private extension URLRequest {
     var serializedHashValue: String {
         var normalizedURL = url
         if let url = url {
-            normalizedURL = MockDuck.shared.delegate?.normalize(url: url)
+            normalizedURL = MockDuck.delegate?.normalize(url: url)
         }
 
         var hashData = Data()
@@ -89,7 +89,7 @@ private extension URLRequest {
         if
             let body = httpBody,
             let url = url,
-            MockDuck.shared.delegate?.useBodyInRequestHash(url: url) ?? true
+            MockDuck.delegate?.useBodyInRequestHash(url: url) ?? true
         {
             hashData.append(body)
         }
@@ -122,7 +122,7 @@ extension MockSerializableData {
             if let path = normalizedURL?.path, path.count > 0 {
                 name = name.appending(path)
             }
-            if MockDuck.shared.isVerbose {
+            if MockDuck.isVerbose {
                 print("Normalized basename: \(name)")
             }
             return name
@@ -131,7 +131,7 @@ extension MockSerializableData {
 
     public var normalizedURL: URL? {
         guard let url = url else { return nil }
-        return MockDuck.shared.delegate?.normalize(url: url)
+        return MockDuck.delegate?.normalize(url: url)
     }
 
     public var dataSuffix: String? {

--- a/MockDuck/Sources/MockURLProtocol.swift
+++ b/MockDuck/Sources/MockURLProtocol.swift
@@ -21,7 +21,7 @@ public class MockURLProtocol: URLProtocol, URLSessionDelegate, URLSessionDataDel
     let session: Foundation.URLSession
 
     override init(request: URLRequest, cachedResponse: CachedURLResponse?, client: URLProtocolClient?) {
-        session = MockDuck.shared.session
+        session = MockDuck.session
         
         // Always ignore the cached response to make sure it's being sourced from the mocks
         super.init(
@@ -32,10 +32,10 @@ public class MockURLProtocol: URLProtocol, URLSessionDelegate, URLSessionDataDel
     
     override public class func canInit(with request: URLRequest) -> Bool {
         guard
-            (MockDuck.shared.enabled ||
-            MockDuck.shared.baseURL != nil ||
-            MockDuck.shared.recordURL != nil ||
-            MockDuck.shared.hasRegisteredRequestMocks())
+            (MockDuck.enabled ||
+            MockDuck.baseURL != nil ||
+            MockDuck.recordURL != nil ||
+            MockDuck.session.bundle.hasRegisteredRequestMocks())
             else { return false }
         
         // Bail out if the request has already been handled.


### PR DESCRIPTION
It is not useful to instantiate multiple instances of MockDuck. So
let's remove the shared instance and instead use static variables
and functions to make the MockDuck API simpler.