### PR TITLE
Allow MockDuck to affect other URLSessions

### DIFF
--- a/MockDuck.xcodeproj/project.pbxproj
+++ b/MockDuck.xcodeproj/project.pbxproj
@@ -7,12 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		637F1D562146E73800767EFF /* MockDuckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637F1D552146E73800767EFF /* MockDuckTests.swift */; };
 		63C6D87921405F7600AA5700 /* SerializationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C6D87821405F7600AA5700 /* SerializationUtils.swift */; };
 		63C6D87B21407BD700AA5700 /* RequestHashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C6D87A21407BD700AA5700 /* RequestHashTests.swift */; };
 		63C6D87D214080C800AA5700 /* MockURLProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C6D87C214080C800AA5700 /* MockURLProtocolTests.swift */; };
 		63C6D87F2140853E00AA5700 /* MockBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C6D87E2140853E00AA5700 /* MockBundleTests.swift */; };
-		63D24C982142C51900D7CDCC /* CryptoUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D24C972142C51900D7CDCC /* CryptoUtils.swift */; };
 		63C6D8B82142BDB600AA5700 /* MockRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C6D8B72142BDB600AA5700 /* MockRequest.swift */; };
+		63D24C982142C51900D7CDCC /* CryptoUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D24C972142C51900D7CDCC /* CryptoUtils.swift */; };
 		7A4FD5C020618A250081600A /* MockDuck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4FD5BF20618A250081600A /* MockDuck.swift */; };
 		7A4FD5C4206199F90081600A /* MockDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4FD5C3206199F90081600A /* MockDataTask.swift */; };
 		7A65B59520603CCD0056B4BB /* RequestHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A65B59320603CCD0056B4BB /* RequestHandlerTests.swift */; };
@@ -38,6 +39,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		637F1D552146E73800767EFF /* MockDuckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDuckTests.swift; sourceTree = "<group>"; };
 		63C6D87821405F7600AA5700 /* SerializationUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializationUtils.swift; sourceTree = "<group>"; };
 		63C6D87A21407BD700AA5700 /* RequestHashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestHashTests.swift; sourceTree = "<group>"; };
 		63C6D87C214080C800AA5700 /* MockURLProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLProtocolTests.swift; sourceTree = "<group>"; };
@@ -147,8 +149,9 @@
 		7A65B59220603CCD0056B4BB /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				63C6D87C214080C800AA5700 /* MockURLProtocolTests.swift */,
 				63C6D87E2140853E00AA5700 /* MockBundleTests.swift */,
+				637F1D552146E73800767EFF /* MockDuckTests.swift */,
+				63C6D87C214080C800AA5700 /* MockURLProtocolTests.swift */,
 				7A65B59320603CCD0056B4BB /* RequestHandlerTests.swift */,
 				63C6D87A21407BD700AA5700 /* RequestHashTests.swift */,
 			);
@@ -336,6 +339,7 @@
 			files = (
 				63C6D87B21407BD700AA5700 /* RequestHashTests.swift in Sources */,
 				63C6D87F2140853E00AA5700 /* MockBundleTests.swift in Sources */,
+				637F1D562146E73800767EFF /* MockDuckTests.swift in Sources */,
 				7A65B59520603CCD0056B4BB /* RequestHandlerTests.swift in Sources */,
 				63C6D87D214080C800AA5700 /* MockURLProtocolTests.swift in Sources */,
 			);

--- a/MockDuckTests/Sources/MockDuckTests.swift
+++ b/MockDuckTests/Sources/MockDuckTests.swift
@@ -1,0 +1,21 @@
+//
+//  MockDuckTests.swift
+//  MockDuckTests
+//
+//  Created by Sebastian Celis on 9/10/18.
+//  Copyright © 2018 BuzzFeed, Inc. All rights reserved.
+//
+
+import Foundation
+@testable import MockDuck
+import XCTest
+
+class MockDuckTests: XCTestCase {
+    func testURLProtocolIsInjected() {
+        MockDuck.enabled = true
+        let defaultConfig = URLSessionConfiguration.default
+        XCTAssertTrue(defaultConfig.protocolClasses?.contains { $0 == MockURLProtocol.self } == true)
+        let ephemeralConfig = URLSessionConfiguration.default
+        XCTAssertTrue(ephemeralConfig.protocolClasses?.contains { $0 == MockURLProtocol.self } == true)
+    }
+}


### PR DESCRIPTION
* Add a function for preparing any URLSessionConfiguration for use by
MockDuck. This can be called on any URLSessionConfiguration object to
inject MockURLProtocol as a valid protocolClass, enabling MockDuck to
handle any requests made by the URLSession configured by that object.

* Swizzle URLSessionConfiguration.default and
URLSessionConfiguration.ephemeral to inject MockURLProtocol as a valid
protocolClass. This allows MockDuck to work with other frameworks
(like Alamofire) with no additional configuration.