### PR TITLE
Reset simulators in CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,5 +12,12 @@ jobs:
       - checkout
 
       - run:
+          name: Reset Simulators
+          command: |
+              export LC_ALL=en_US.UTF-8
+              export LANG=en_US.UTF-8
+              fastlane snapshot reset_simulators --force
+
+      - run:
           name: Run Tests
           command: make test

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ test-ios:
 	set -o pipefail && \
 	xcodebuild test \
 		-scheme MockDuck \
-		-destination platform="iOS Simulator,name=iPad Pro (12.9-inch) (2nd generation),OS=12.0" \
+		-destination platform="iOS Simulator,name=iPhone X,OS=12.0" \
 		| xcpretty
 
 test-tvos:
@@ -15,4 +15,4 @@ test-tvos:
 test-macos:
 	swift test -Xswiftc "-target" -Xswiftc "x86_64-apple-macosx10.12"
 
-test: test-ios test-macos
+test: test-ios test-tvos test-macos


### PR DESCRIPTION
This allows us to re-enable tvOS tests in CircleCI.

Fixes #11