### PR TITLE
Added a safety check to recordingURL

### DIFF
--- a/MockDuck/Sources/MockDuck.swift
+++ b/MockDuck/Sources/MockDuck.swift
@@ -104,9 +104,8 @@ public final class MockDuck {
                 !newValue.isFileURL
             {
                 assertionFailure("Invalid recordingURL: URL does not match file scheme")
-            } else {
-                checkConfigureMockDuck()
             }
+            checkConfigureMockDuck()
         }
         didSet {
             mockBundle.recordingURL = recordingURL

--- a/MockDuck/Sources/MockDuck.swift
+++ b/MockDuck/Sources/MockDuck.swift
@@ -99,7 +99,14 @@ public final class MockDuck {
     /// by pointing to this same data using `loadingURL`.
     public static var recordingURL: URL? {
         willSet {
-            checkConfigureMockDuck()
+            if
+                let newValue = newValue,
+                !newValue.isFileURL
+            {
+                assertionFailure("Invalid recordingURL: URL does not match file scheme")
+            } else {
+                checkConfigureMockDuck()
+            }
         }
         didSet {
             mockBundle.recordingURL = recordingURL


### PR DESCRIPTION
the `recordingURL` could be set to a url that would fail when trying to write a file to disk. I added a check when setting the `recordingURL` to help prevent that from happening