### PR TITLE
Not calling normalized request

### DIFF
--- a/MockDuck/Sources/MockBundle.swift
+++ b/MockDuck/Sources/MockBundle.swift
@@ -27,8 +27,11 @@ final class MockBundle {
     ///
     /// - Parameter request: URLRequest to attempt to load
     /// - Returns: The MockRequestResponse, if it can be loaded
-    func loadRequestResponse(for request: URLRequest) -> MockRequestResponse? {
-        guard let fileName = SerializationUtils.fileName(for: .request(request)) else { return nil }
+    func loadRequestResponse(for request: URLRequest, hash: String) -> MockRequestResponse? {
+        print("hash:::::::", hash)
+        guard let fileName = SerializationUtils.fileName(for: .request(request), hash: hash) else { return nil }
+
+        print("--------", #function, fileName)
 
         var targetURL: URL?
         var targetLoadingURL: URL?
@@ -66,14 +69,14 @@ final class MockBundle {
 
                 // Load the response data if the format is supported.
                 // This should be the same filename with a different extension.
-                if let dataFileName = SerializationUtils.fileName(for: .responseData(sequence, sequence)) {
+                if let dataFileName = SerializationUtils.fileName(for: .responseData(sequence, sequence), hash: hash) {
                     let dataURL = targetLoadingURL.appendingPathComponent(dataFileName)
                     sequence.responseData = try Data(contentsOf: dataURL)
                 }
 
                 // Load the request body if the format is supported.
                 // This should be the same filename with a different extension.
-                if let bodyFileName = SerializationUtils.fileName(for: .requestBody(sequence)) {
+                if let bodyFileName = SerializationUtils.fileName(for: .requestBody(sequence), hash: hash) {
                     let bodyURL = targetLoadingURL.appendingPathComponent(bodyFileName)
                     sequence.request.httpBody = try Data(contentsOf: bodyURL)
                 }
@@ -92,11 +95,13 @@ final class MockBundle {
     /// into a separate file that lives along side the recorded request.
     ///
     /// - Parameter requestResponse: MockRequestResponse containing the request, response, and data
-    func record(requestResponse: MockRequestResponse) {
+    func record(requestResponse: MockRequestResponse, hash: String) {
         guard
             let recordingURL = recordingURL,
-            let outputFileName =  SerializationUtils.fileName(for: .request(requestResponse))
+            let outputFileName =  SerializationUtils.fileName(for: .request(requestResponse), hash: hash)
             else { return }
+
+                print("--------", #function, outputFileName)
 
         do {
             let outputURL = recordingURL.appendingPathComponent(outputFileName)
@@ -113,14 +118,14 @@ final class MockBundle {
 
                 // write out request body if the format is supported.
                 // This should be the same filename with a different extension.
-                if let requestBodyFileName = SerializationUtils.fileName(for: .requestBody(requestResponse)) {
+                if let requestBodyFileName = SerializationUtils.fileName(for: .requestBody(requestResponse), hash: hash) {
                     let requestBodyURL = recordingURL.appendingPathComponent(requestBodyFileName)
                     try requestResponse.request.httpBody?.write(to: requestBodyURL, options: [.atomic])
                 }
 
                 // write out response data if the format is supported.
                 // This should be the same filename with a different extension.
-                if let dataFileName = SerializationUtils.fileName(for: .responseData(requestResponse, requestResponse)) {
+                if let dataFileName = SerializationUtils.fileName(for: .responseData(requestResponse, requestResponse), hash: hash) {
                     let dataURL = recordingURL.appendingPathComponent(dataFileName)
                     try requestResponse.responseData?.write(to: dataURL, options: [.atomic])
                 }

--- a/MockDuck/Sources/MockDataTask.swift
+++ b/MockDuck/Sources/MockDataTask.swift
@@ -31,7 +31,8 @@ final class MockDataTask: URLSessionDataTask {
 
     // On task execution, look for a saved request or kick off the fallback request.
     override func resume() {
-        if let sequence = MockDuck.mockBundle.loadRequestResponse(for: request) {
+        let hash = request.requestHash
+        if let sequence = MockDuck.mockBundle.loadRequestResponse(for: request, hash: hash) {
             // The request is found. Load the MockRequestResponse and call the completion/finish
             // with the stored data.
             completion(sequence, nil)
@@ -43,7 +44,7 @@ final class MockDataTask: URLSessionDataTask {
                     self.completion(nil, error)
                 } else if let response = response {
                     let requestResponse = MockRequestResponse(request: self.request, response: response, responseData: data)
-                    MockDuck.mockBundle.record(requestResponse: requestResponse)
+                    MockDuck.mockBundle.record(requestResponse: requestResponse, hash: hash)
                     self.completion(requestResponse, nil)
                 } else {
                     self.completion(nil, ErrorType.unknown)

--- a/MockDuck/Sources/MockDuck.swift
+++ b/MockDuck/Sources/MockDuck.swift
@@ -20,7 +20,7 @@ public protocol MockDuckDelegate: class {
     ///
     /// - Parameter request: The request to normalize
     /// - Returns: The normalized request
-    func normalizedRequest(for request: URLRequest) -> URLRequest
+    func normalizedRequest(for request: URLRequest, forHashValue: Bool) -> URLRequest
 }
 
 /// Public-facing errors that MockDuck can throw.

--- a/MockDuck/Sources/MockDuck.swift
+++ b/MockDuck/Sources/MockDuck.swift
@@ -20,7 +20,7 @@ public protocol MockDuckDelegate: class {
     ///
     /// - Parameter request: The request to normalize
     /// - Returns: The normalized request
-    func normalizedRequest(for request: URLRequest, forHashValue: Bool) -> URLRequest
+    func normalizedRequest(for request: URLRequest) -> URLRequest
 }
 
 /// Public-facing errors that MockDuck can throw.

--- a/MockDuck/Sources/MockSerializable.swift
+++ b/MockDuck/Sources/MockSerializable.swift
@@ -74,7 +74,7 @@ extension MockRequestResponse: HashableMockData {
 // This is the file name hash value that all of the serialization uses.
 private extension URLRequest {
     var serializedHashValue: String {
-        let normalizedRequest = MockDuck.delegate?.normalizedRequest(for: self) ?? self
+        let normalizedRequest = MockDuck.delegate?.normalizedRequest(for: self, forHashValue: true) ?? self
 
         var hashData = Data()
 
@@ -128,7 +128,7 @@ extension MockSerializableData {
 
     var normalizedURL: URL? {
         guard let url = url else { return nil }
-        return MockDuck.delegate?.normalizedRequest(for: URLRequest(url: url)).url ?? url
+        return MockDuck.delegate?.normalizedRequest(for: URLRequest(url: url), forHashValue: false).url ?? url
     }
 
     var dataSuffix: String? {

--- a/MockDuck/Sources/MockURLProtocol.swift
+++ b/MockDuck/Sources/MockURLProtocol.swift
@@ -48,6 +48,9 @@ class MockURLProtocol: URLProtocol, URLSessionDelegate, URLSessionDataDelegate {
         // it's already been handled once, bail out in the 'canInit' method.
         URLProtocol.setProperty(true, forKey: Constants.ProtocolHandled, in: newRequest)
 
+        let normalizedRequest = MockDuck.delegate?.normalizedRequest(for: request) ?? request
+        URLProtocol.setProperty(normalizedRequest, forKey: "normalizedRequest", in: newRequest)
+
         // Complete the request using our `MockSession`. On completion, call all the necessary
         // URLClient methods to communicate the results back to the caller.
         sessionTask = MockDuck.mockSession.dataTask(

--- a/MockDuck/Sources/Utilities/SerializationUtils.swift
+++ b/MockDuck/Sources/Utilities/SerializationUtils.swift
@@ -19,27 +19,27 @@ final class SerializationUtils {
 
     /// Used to determine the file name for a particular piece of data that we may want to
     /// serialize to or from disk.
-    static func fileName(for type: MockFileTarget) -> String? {
+    static func fileName(for type: MockFileTarget, hash: String) -> String? {
         var data: MockSerializableData
-        var hashValue: String
+        var hashValue: String = hash
         var componentSuffix: String = ""
         var baseName: String = ""
         var pathExtension: String?
 
         switch type {
         case .request(let request):
-            hashValue = request.requestHash
+//            hashValue = request.requestHash
             data = request.serializableRequest
             baseName = data.baseName
             pathExtension = "json"
         case .requestBody(let request):
-            hashValue = request.requestHash
+//            hashValue = request.requestHash
             data = request.serializableRequest
             baseName = data.baseName
             componentSuffix = "-request"
             pathExtension = data.dataSuffix
         case .responseData(let request, let response):
-            hashValue = response.requestHash
+//            hashValue = response.requestHash
             data = response.serializableResponse
             baseName = request.serializableRequest.baseName
             componentSuffix = "-response"

--- a/MockDuck/Sources/Utilities/SerializationUtils.swift
+++ b/MockDuck/Sources/Utilities/SerializationUtils.swift
@@ -19,27 +19,23 @@ final class SerializationUtils {
 
     /// Used to determine the file name for a particular piece of data that we may want to
     /// serialize to or from disk.
-    static func fileName(for type: MockFileTarget, hash: String) -> String? {
+    static func fileName(for type: MockFileTarget, hash hashValue: String) -> String? {
         var data: MockSerializableData
-        var hashValue: String = hash
         var componentSuffix: String = ""
         var baseName: String = ""
         var pathExtension: String?
 
         switch type {
         case .request(let request):
-//            hashValue = request.requestHash
             data = request.serializableRequest
             baseName = data.baseName
             pathExtension = "json"
         case .requestBody(let request):
-//            hashValue = request.requestHash
             data = request.serializableRequest
             baseName = data.baseName
             componentSuffix = "-request"
             pathExtension = data.dataSuffix
         case .responseData(let request, let response):
-//            hashValue = response.requestHash
             data = response.serializableResponse
             baseName = request.serializableRequest.baseName
             componentSuffix = "-response"


### PR DESCRIPTION
Hi, 
PR #21 started a discussion and raised a different approach suggested by @scelis . 
This PR tries to implement that suggestion.

Idea: 
We only call `normalisedRequest` in the resume() method to get the hash of the request. From there on, that hash is passed to both `loadRequest` and `record`. The way we avoid calling the `normalizedRequest` is saving it in a URLProtocol property. 
After that, every time we need the normalisedRequest, we simply access the URLProtocol. This was your suggestion. Now, while doing so, we hit a block, URLResponse doesn't actually access the request so we can pass it to URLProtocol. But to my understanding, we really don't need it, so what was done was, removing the normalizedURL implementation from the `MockSerializableData` protocol and add it explicitly to URLRequest and URLResponse. For the request part we use the URLProtocol using "self" and for the URLResponse we simply return the url. This worked for a few of our UI tests and we didn't see any issues until now. 
Of course, this PR should be subject to discussion and change if necessary. 

We also noticed that  when we create a custom URLProtocol the request's httpBody returns nil (reference [here](https://stackoverflow.com/questions/36555018/why-is-the-httpbody-of-a-request-inside-an-nsurlprotocol-subclass-always-nil)), so I shamelessly copied that implementation and added it to the recording method. 

Please let me know what you think about this. I know it's a bit hacky, but at least it doesn't change the library api. 

