### PR TITLE
Checks both .httpBody and .httpBodyStream when recording requests

### DIFF
--- a/MockDuck/Sources/MockBundle.swift
+++ b/MockDuck/Sources/MockBundle.swift
@@ -111,7 +111,8 @@ final class MockBundle {
                 // This should be the same filename with a different extension.
                 if let requestBodyFileName = requestResponse.fileName(for: .requestBody) {
                     let requestBodyURL = recordingURL.appendingPathComponent(requestBodyFileName)
-                    try requestResponse.request.httpBody?.write(to: requestBodyURL, options: [.atomic])
+                    let body = requestResponse.request.httpBody ?? requestResponse.request.httpBodyStreamData
+                    try body?.write(to: requestBodyURL, options: [.atomic])
                 }
 
                 // write out response data if the format is supported.

--- a/MockDuck/Sources/RequestResponseCommonProtocol.swift
+++ b/MockDuck/Sources/RequestResponseCommonProtocol.swift
@@ -50,4 +50,22 @@ extension URLRequest: RequestResponseCommonProtocol {
     var contentType: String? {
         return headers?["Content-Type"]
     }
+    
+    var httpBodyStreamData: Data? {
+            
+        guard let bodyStream = self.httpBodyStream else { return nil }
+        bodyStream.open()
+        let bufferSize: Int = 1024
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        var dat = Data()
+        
+        while bodyStream.hasBytesAvailable {
+            let readDat = bodyStream.read(buffer, maxLength: bufferSize)
+            dat.append(buffer, count: readDat)
+        }
+        
+        buffer.deallocate()
+        bodyStream.close()
+        return dat
+    }
 }


### PR DESCRIPTION
Sometimes it happens that .httpBody of a post request is empty, but .httpBodyStream contains the body of the request. In this case, when recording, the library will not save any -request file (because .httpBody is empty) but when loading it tries to load that file because the content type of the request is application/json and so the loading fails.

This PR fixes this

See here: https://github.com/buzzfeed/MockDuck/issues/23