### PR TITLE
update README's installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ pod 'MockDuck'
 [Carthage](https://github.com/Carthage/Carthage) is a simple, decentralized dependency manager for Cocoa. To integrate MockDuck into your project, add the following to your `Cartfile`:
 
 ```ruby
-github "BuzzFeed/MockDuck" "master"
+github "BuzzFeed/MockDuck" "main"
 ```
 
 ### Swift Package Manager
@@ -90,7 +90,7 @@ github "BuzzFeed/MockDuck" "master"
 
 ```swift
     dependencies: [
-        .package(url: "https://github.com/BuzzFeed/MockDuck", .branch("master"))
+        .package(url: "https://github.com/BuzzFeed/MockDuck", .branch("main"))
     ],
     targets: [
         .target(name: "your-target-name", dependencies: ["MockDuck"])


### PR DESCRIPTION
Update README's installation instructions to use "main" branch, which is the default branch